### PR TITLE
Patch: Redefine saveCNCLIP

### DIFF
--- a/Stable_Diffusion_Vystmedia.ipynb
+++ b/Stable_Diffusion_Vystmedia.ipynb
@@ -43,6 +43,8 @@
         "#@markdown (EXPERIMENTAL) Centang jika ingin menggunakan/menyimpan Config di GDrive\n",
         "saveConfig = False #@param {type:\"boolean\"}\n",
         "\n",
+        "saveCNCLIP = False\n"
+        "\n",
         "if not useGDrive and (saveModels or saveCNCLIP or saveConfig):\n",
         "  print(\"Peringatan: useGdrive tidak aktif tapi anda menyalakn fitur simpan di Gdrive. Harap periksa kembali.\")\n",
         "  import sys\n",


### PR DESCRIPTION
Fix for NameError: name 'saveCNCLIP' is not defined.